### PR TITLE
Fixed incorrect parameter to sendmails -f flag

### DIFF
--- a/lib/MIME/Lite.pm
+++ b/lib/MIME/Lite.pm
@@ -2716,7 +2716,7 @@ sub send_by_sendmail {
         if ( $p{SetSender} ) {
             my $from = $p{FromSender} || ( $self->get('From') )[0];
             if ($from) {
-                my ($from_addr) = extract_full_addrs($from);
+                my ($from_addr) = extract_only_addrs($from);
                 push @cmd, "-f$from_addr" if $from_addr;
             }
         }


### PR DESCRIPTION
This patch fixes the issue with send_by_sendmail using the full value of
FromSender or the From header, insted using only the email-address.
This is the expected value for sendmails -f flag for at least exim, and
probably a few others.

Closes: https://rt.cpan.org/Public/Bug/Display.html?id=16939
