### PR TITLE
Keep optional modules in prereqs even if installed

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ my %extra_prereq = (
 for my $module (sort keys %extra_prereq) {
   local $@;
   my $ok = eval "require $module; \$extra_prereq{\$module} && \$module->VERSION(\$extra_prereq{\$module}); 1";
-  delete $extra_prereq{ $module } if $ok;
+  $prereq{ $module } = delete $extra_prereq{ $module } if $ok;
 }
 
 my %prereq = (


### PR DESCRIPTION
For repeatability between installations, keep these optional modules in the required prereq list if they are already installed.


(This distribution is another prime candidate for dzilification... any sort of interaction with the user really needs to be marked with `dynamic_config => 1` in metadata as well.)