### PR TITLE
Ssl support

### DIFF
--- a/lib/MIME/Lite.pm
+++ b/lib/MIME/Lite.pm
@@ -79,6 +79,10 @@ with authentication
 
     MIME::Lite->send('smtp','some.host', AuthUser=>$user, AuthPass=>$pass);
 
+using SSL
+
+    MIME::Lite->send('smtp','some.host', SSL => 1, Port => 465 );
+
 =head1 DESCRIPTION
 
 In the never-ending quest for great taste with fewer calories,
@@ -2841,6 +2845,7 @@ if the send was successful or not.
 my @_mail_opts     = qw( Size Return Bits Transaction Envelope );
 my @_recip_opts    = qw( SkipBad );
 my @_net_smtp_opts = qw( Hello LocalAddr LocalPort Timeout
+                         AuthUser AuthPass SSL
                          Port ExactAddresses Debug );
 # internal:  qw( NoAuth AuthUser AuthPass To From Host);
 

--- a/lib/MIME/Lite.pm
+++ b/lib/MIME/Lite.pm
@@ -31,7 +31,7 @@ Create and send using the default send method for your OS a single-part message:
     );
     $msg->send; # send via default
 
-Create a multipart message (i.e., one with attachments) and send it SMTP
+Create a multipart message (i.e., one with attachments) and send it via SMTP
 
     ### Create a new multipart message:
     $msg = MIME::Lite->new(
@@ -53,7 +53,7 @@ Create a multipart message (i.e., one with attachments) and send it SMTP
         Filename => 'logo.gif',
         Disposition => 'attachment'
     );
-    ### use Net:SMTP to do the sending
+    ### use Net::SMTP to do the sending
     $msg->send('smtp','some.host', Debug=>1 );
 
 Output a message:


### PR DESCRIPTION
This adds very simplistic SSL support for sending by SMTP by allowing to pass through the
relevant parameters to Net::SMTP

I know that MIME::Lite is not actively maintained by you. If you're interested, I'm willing to take over maintenance, at least for merging the current pull requests and getting them onto a new CPAN release.