### PR TITLE
Don't suggest encode_utf8 in example

### DIFF
--- a/lib/MIME/Lite.pm
+++ b/lib/MIME/Lite.pm
@@ -3315,7 +3315,7 @@ Text: "E<iquest>Quieres ganar muchos E<euro>'s?"
 
 
     use MIME::Lite;
-    use Encode qw(encode encode_utf8 );
+    use Encode qw(encode);
 
     my $to      = "Ram\363n Nu\361ez <foo\@bar.com>";
     my $subject = "\241Aqu\355 est\341!";
@@ -3326,7 +3326,7 @@ Text: "E<iquest>Quieres ganar muchos E<euro>'s?"
         From    => 'me@myhost.com',
         To      => encode( 'MIME-Header', $to ),
         Subject => encode( 'MIME-Header', $subject ),
-        Data    => encode_utf8($text)
+        Data    => encode( 'UTF-8', $text )
     );
     $msg->attr( 'content-type' => 'text/plain; charset=utf-8' );
     $msg->send;


### PR DESCRIPTION
encode_utf8 shouldn't be used, just use the same encode() function used for the rest of the example.